### PR TITLE
Fix sidebar and WebView auto-opening during session join

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -159,8 +159,6 @@ const App = () => {
     setActiveIcon,
     explorerPanelSize,
     setExplorerPanelSize,
-    isExplorerCollapsed,
-    toggleExplorerPanel,
   });
 
   // Generic function to set active icon for simple panels (files, search, chat etc.)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -229,6 +229,7 @@ const App = () => {
     handleMouseDown: handleWebViewPanelMouseDown,
     togglePanel: toggleWebViewPanel,
     isCollapsed: isWebViewCollapsed,
+    setSize: setWebViewPanelSize,
   } = useResizablePanel({
     initialSize: () =>
       (mainContentRef.current?.offsetWidth ?? window.innerWidth * 0.85) *
@@ -243,6 +244,14 @@ const App = () => {
       (mainContentRef.current?.offsetWidth ?? window.innerWidth * 0.85) *
       DEFAULT_WEBVIEW_WIDTH_FRACTION,
   });
+
+  // Effect to handle WebView state during prompting
+  useEffect(() => {
+    if (joinState === "prompting" && !isWebViewCollapsed) {
+      // Collapse WebView when entering prompting state
+      setWebViewPanelSize(0);
+    }
+  }, [joinState, isWebViewCollapsed, setWebViewPanelSize]);
 
   const { sendChatMessage } = useCollaborationSession({
     sessionId,
@@ -387,7 +396,8 @@ const App = () => {
   const handleRunCode = async () => {
     const activeFile = openFiles.find((f) => f.id === activeFileId);
     if (activeFile && activeFile.language === "html") {
-      if (isWebViewCollapsed) {
+      // Don't auto-open WebView during prompting state
+      if (joinState !== "prompting" && isWebViewCollapsed) {
         toggleWebViewPanel();
       }
       return; // Don't execute HTML, just show it in the webview

--- a/frontend/src/hooks/useSessionManager.ts
+++ b/frontend/src/hooks/useSessionManager.ts
@@ -15,8 +15,6 @@ export interface SessionManagerHookProps {
   setActiveIcon: (icon: string | null) => void;
   explorerPanelSize: number;
   setExplorerPanelSize: (size: number) => void;
-  isExplorerCollapsed: boolean;
-  toggleExplorerPanel: () => void;
   // userId: string;
 }
 
@@ -50,8 +48,6 @@ export const useSessionManager = ({
   setActiveIcon,
   explorerPanelSize,
   setExplorerPanelSize,
-  isExplorerCollapsed,
-  toggleExplorerPanel,
 }: SessionManagerHookProps): SessionManagerHookResult => {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [isSessionActive, setIsSessionActive] = useState<boolean>(false);
@@ -185,21 +181,14 @@ export const useSessionManager = ({
       joinState === "joined" &&
       !hasShownInitialParticipants
     ) {
-      if (isExplorerCollapsed) {
-        toggleExplorerPanel();
-      }
-      // Delay showing participants to give collaboration hook time
-      setTimeout(() => {
-        setActiveIcon("share");
-        setHasShownInitialParticipants(true);
-      }, 150);
+      // Close the sidebar after joining instead of opening participants panel
+      setActiveIcon(null);
+      setHasShownInitialParticipants(true);
     }
   }, [
     isSessionActive,
     joinState,
     hasShownInitialParticipants,
-    isExplorerCollapsed,
-    toggleExplorerPanel,
     setActiveIcon,
     setHasShownInitialParticipants,
   ]);


### PR DESCRIPTION
## Summary
Improves UX during session join by preventing unwanted UI auto-opening:

- **WebView**: No longer auto-opens during prompting state
- **Sidebar**: Closes after joining instead of forcing participants panel open

## Changes
- Modified `handleRunCode` to prevent WebView auto-opening during prompting
- Updated `useSessionManager` to close sidebar after join (`setActiveIcon(null)`)
- Removed unused parameters and fixed TypeScript errors

## Result
Clean, minimal UI during join flow - both panels stay closed until manually opened.

## Testing
✅ Docker build successful  
✅ Join flow works correctly  
✅ No TypeScript errors