### PR TITLE
docs: add CONTRIBUTING.md and streamline README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing to CodeCafé
+
+Thank you for your interest in contributing to CodeCafé! We're excited to have you join our mission to make collaborative coding more accessible and seamless.
+
+## Getting Started
+
+### Prerequisites
+
+- **Git**
+- **Java JDK 23+** and **Maven**
+- **Node.js 18+** and **npm 9+**
+- **Redis Server** (or Docker for containerized setup)
+
+### Development Setup
+
+#### Option 1: Docker Setup (Recommended)
+
+```bash
+git clone https://github.com/YOUR_USERNAME/codecafe.git
+cd codecafe
+docker-compose up
+```
+
+#### Option 2: Manual Setup
+
+```bash
+git clone https://github.com/YOUR_USERNAME/codecafe.git
+cd codecafe
+
+# Start Redis
+redis-server &
+
+# Backend setup
+cd backend
+echo "spring.redis.host=localhost
+spring.redis.port=6379" > src/main/resources/application.properties
+./mvnw install
+./mvnw spring-boot:run &
+
+# Frontend setup
+cd ../frontend
+echo "VITE_BACKEND_URL=http://localhost:8080" > .env
+npm install
+npm run dev
+```
+
+## How to Contribute
+
+1. **Fork the repository** and create a feature branch: `git checkout -b feature/your-feature-name`
+2. **Make your changes** following our development guidelines below
+3. **Test thoroughly** - especially real-time collaboration with multiple browser windows
+4. **Submit a pull request** with a clear description of your changes
+
+## Development Guidelines
+
+### Frontend (React/TypeScript)
+
+- Use functional components with hooks
+- Zustand for global state, local state for component-specific data
+- Tailwind CSS for styling
+- Maintain TypeScript strict type safety
+- Run `npm run lint` and `npm run format` before committing
+
+### Backend (Java/Spring Boot)
+
+- Follow standard Java conventions
+- Maintain clean separation between controllers, services, and repositories
+- Add JavaDoc comments for public methods
+- Use proper exception handling
+
+### Commit Messages
+
+Use conventional commits format:
+
+```
+feat: add user authentication system
+fix: resolve WebSocket connection issues
+docs: update API documentation
+```
+
+## Testing
+
+```bash
+# Frontend
+cd frontend && npm test
+
+# Backend
+cd backend && ./mvnw test
+```
+
+**Manual Testing Checklist:**
+
+- Test real-time collaboration with multiple browser windows
+- Verify WebSocket connections work correctly
+- Test the integrated terminal and web preview
+
+## Reporting Issues
+
+When reporting bugs or requesting features:
+
+- Provide a clear description
+- Include steps to reproduce (for bugs)
+- Mention your browser/OS if relevant
+- Add screenshots if helpful
+
+## Areas We're Looking For
+
+- **Enhanced Chat Features**
+- **Performance Improvements**
+- **Accessibility & Mobile Responsiveness**
+
+## Questions?
+
+- Create a GitHub issue with the "question" label
+- Check existing documentation in README.md
+
+Thanks for contributing to CodeCafé!

--- a/README.md
+++ b/README.md
@@ -58,79 +58,29 @@ Our implementation handles the complex synchronization challenges of collaborati
 
 This enables truly fluid, Google Docs-like collaboration where everyone can type simultaneously without stepping on each other's toes.
 
+## CI/CD Pipeline
+
+CodeCafé features a fully automated CI/CD pipeline built with GitHub Actions:
+
+- **Continuous Integration:** Automated testing for both frontend and backend on every pull request and push
+- **Continuous Deployment:** Automatic deployment to production (AWS EC2 + Vercel) when changes are merged to main
+- **Quality Assurance:** Ensures code quality and prevents regressions before deployment
+
+This enables rapid, reliable development cycles while maintaining production stability.
+
 ## Quick Start
 
-### Option 1: Using Docker (Recommended)
-
-The easiest way to get started with CodeCafé is to use Docker:
+Want to try CodeCafé locally? The easiest way is with Docker:
 
 ```bash
-# Clone the repo
 git clone https://github.com/mrktsm/codecafe.git
 cd codecafe
-
-# Start all services using Docker Compose
 docker-compose up
 ```
 
-Access the app in your browser at http://localhost:80
+Access the app at http://localhost:80
 
-### Option 2: Manual Setup
-
-**Prerequisites:** Git, Java JDK 23+, Maven, Node.js 18+, npm 9+, Redis Server
-
-**Setup and Run:**
-
-```bash
-# Clone the repo
-git clone https://github.com/mrktsm/codecafe.git
-cd codecafe
-
-# Start Redis (keep this running in a separate terminal or as a background service)
-redis-server &
-
-# Create backend config file with Redis connection
-mkdir -p backend/src/main/resources
-echo "spring.redis.host=localhost
-spring.redis.port=6379" > backend/src/main/resources/application.properties
-
-# Run the backend
-cd backend
-./mvnw install
-./mvnw spring-boot:run &
-
-# Create frontend config and run
-cd ../frontend
-echo "VITE_BACKEND_URL=http://localhost:8080" > .env
-npm install
-npm run dev
-```
-
-Access the app in your browser at the URL shown in terminal (typically http://localhost:5173).
-
-## CI/CD Pipeline
-
-CodeCafé uses GitHub Actions for continuous integration and deployment:
-
-- **CI Pipeline:** Automatically runs tests for both frontend and backend on every pull request and push to main/develop branches.
-- **CD Pipeline:** Automatically deploys:
-  - Backend to AWS EC2 when pushing to the main branch
-  - Frontend to Vercel when pushing to the main branch
-
-### Setting up CI/CD for your fork:
-
-1. **For AWS deployment:**
-
-   - Add the following secrets to your GitHub repository:
-     - `AWS_ACCESS_KEY_ID`
-     - `AWS_SECRET_ACCESS_KEY`
-     - `AWS_REGION`
-
-2. **For Vercel deployment:**
-   - Add the following secrets to your GitHub repository:
-     - `VERCEL_TOKEN`
-     - `VERCEL_ORG_ID`
-     - `VERCEL_PROJECT_ID`
+For detailed setup instructions, development guidelines, and contribution information, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## On the Horizon
 
@@ -139,10 +89,14 @@ CodeCafé uses GitHub Actions for continuous integration and deployment:
 - Session rewind & history playback
 - Expanded language support & tooling
 
+## Contributing
+
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, guidelines, and how to get started.
+
 ## License
 
 CodeCafé is open-sourced under the [MIT License](https://opensource.org/licenses/MIT).
 
 ---
 
-_Making collaborative coding magic accessible to everyone._ ✨
+_Making collaborative coding magic accessible to everyone._


### PR DESCRIPTION
- Add comprehensive CONTRIBUTING.md with development setup, guidelines, and contribution process
- Streamline README.md by removing redundant setup instructions
- Add concise CI/CD section to highlight automated testing and deployment
- Redirect detailed development info to CONTRIBUTING.md for better organization